### PR TITLE
Remove unset of LDFLAGS and LIBS in configure to fix fopen_ascii issues + support for NO_COLOR

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -21,7 +21,7 @@ if [ "${ZOPEN_BUILD_LINE}" = "STABLE" ]; then
 # Temporary work-around waiting for fopen_ascii function in zoslib so that configure works
 # and
 # Temporary work-around for lack of MAP_ANON support in zoslib mmap emulation
-  export ZOPEN_EXTRA_CFLAGS="-DZEND_MM_ALIGNMENT='(size_t)8' -DZEND_MM_ALIGNMENT_LOG2='(size_t)3' -DZEND_MM_NEED_EIGHT_BYTE_REALIGNMENT=0 -DMAP_ANON=16 -DMAP_ANONYMOUS=16"
+  export ZOPEN_EXTRA_CFLAGS="-DMAP_ANON=16 -DMAP_ANONYMOUS=16"
 else
   export ZOPEN_BOOTSTRAP="./buildconf"
   export ZOPEN_CONFIGURE="./configure"

--- a/buildenv
+++ b/buildenv
@@ -35,10 +35,17 @@ zopen_check_results()
   chk="$1/$2_check.log"
   summary="$1/$2_summary.log"
 
-  actualPasses=$(grep '1;32mPASS' ${chk} | awk ' { print $3; }' | wc -l)
-  actualSkips=$(grep '1;33mSKIP' ${chk} | awk ' { print $3; }' | wc -l)
-  actualFailures=$(grep '1;31mFAIL' ${chk} | awk ' { print $3; }' | wc -l)
-  expectedFailures=111
+  if [ -z "${NO_COLOR}" ]; then
+    actualPasses=$(grep '1;32mPASS' ${chk} | awk ' { print $3; }' | wc -l)
+    actualSkips=$(grep '1;33mSKIP' ${chk} | awk ' { print $3; }' | wc -l)
+    actualFailures=$(grep '1;31mFAIL' ${chk} | awk ' { print $3; }' | wc -l)
+  else
+    actualPasses=$(grep 'PASS' ${chk} | awk ' { print $3; }' | wc -l)
+    actualSkips=$(grep 'SKIP' ${chk} | awk ' { print $3; }' | wc -l)
+    actualFailures=$(grep 'FAIL' ${chk} | awk ' { print $3; }' | wc -l)
+  fi
+
+  expectedFailures=112
 
   totalTests=$((actualPasses+actualSkips+actualFailures))
   echo "actualFailures:${actualFailures}"

--- a/patches/configure.patch
+++ b/patches/configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure b/configure
+index dcf5275d..a1c63789 100755
+--- a/configure
++++ b/configure
+@@ -85439,7 +85439,6 @@ if test "$ac_cv_lib_crypt_crypt" = "yes"; then
+   EXTRA_LIBS="-lcrypt $EXTRA_LIBS -lcrypt"
+ fi
+ 
+-unset LIBS LDFLAGS
+ 
+ 
+ 


### PR DESCRIPTION
When building dev line and upstreaming, we also need to patch the configure.ac:
```
1186 unset LIBS LDFLAGS
```
It probably would make sense to guard with an uname -s check or $host check
